### PR TITLE
Explain recycling and half-life effects on net HWP contribution

### DIFF
--- a/demos/hwp-simulator/index.html
+++ b/demos/hwp-simulator/index.html
@@ -165,7 +165,13 @@
                 <span id="initialCarbon" class="text-2xl font-bold text-indigo-700">0.00 $tCO_2e$</span>
             </div>
             <div class="bg-pink-100 p-4 rounded-lg shadow-md flex justify-between items-center">
-                <span class="text-xl font-medium text-gray-900">Net HWP Contribution (Current Period):</span>
+                <div class="flex flex-col">
+                    <span class="text-xl font-medium text-gray-900">Net HWP Contribution (Current Period):</span>
+                    <span class="text-sm text-pink-900">
+                        Portion of the initial biogenic carbon credited as stored in HWPs for this reporting period (i.e., right after production, before future decay, using ISO 13391 coefficients).
+                        Fibre/Paper recycling rate changes this via its coefficient; half-life inputs only affect the decay chart, not this number.
+                    </span>
+                </div>
                 <span id="hwpContribution" class="text-2xl font-bold text-pink-700">0.00 $tCO_2e$</span>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- clarify in the UI that Fibre/Paper recycling rate changes the net HWP contribution via its coefficient, while half-life inputs only affect the decay chart

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69549f3bf56083269f23e2e421bb10d3)