### PR TITLE
Refine net HWP contribution helper text

### DIFF
--- a/demos/hwp-simulator/index.html
+++ b/demos/hwp-simulator/index.html
@@ -168,7 +168,7 @@
                 <div class="flex flex-col">
                     <span class="text-xl font-medium text-gray-900">Net HWP Contribution (Current Period):</span>
                     <span class="text-sm text-pink-900">
-                        Portion of the initial biogenic carbon credited as stored in HWPs for this reporting period (i.e., right after production, before future decay, using ISO 13391 coefficients).
+                        Computed at time of production without simulating decay with your user-defined half-lives, using Tier-1 ISO coefficients (which themselves reflect default decay/recycling assumptions).
                         Fibre/Paper recycling rate changes this via its coefficient; half-life inputs only affect the decay chart, not this number.
                     </span>
                 </div>


### PR DESCRIPTION
### Motivation
- Clarify wording so users understand the Net HWP Contribution is an immediate post-production credit and not a decay simulation.
- Make explicit that the displayed value uses Tier-1 ISO 13391 coefficients which already embed default decay/recycling assumptions.

### Description
- Replaced the helper text in `demos/hwp-simulator/index.html` for the "Net HWP Contribution (Current Period)" field with: "Computed at time of production without simulating decay with your user-defined half-lives, using Tier-1 ISO coefficients (which themselves reflect default decay/recycling assumptions)."
- This is a one-line UI text change and does not modify any calculation logic.

### Testing
- No automated tests were run for this static text change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964976dc50c83269793e2262b6ebdea)